### PR TITLE
fix: Seperating child ChangeHighLight components from their parents

### DIFF
--- a/src/ChangeHighlight.tsx
+++ b/src/ChangeHighlight.tsx
@@ -31,11 +31,12 @@ const ChangeHighlight: React.FC<Props> = ({
 }) => {
   const [shadowDOM, setShadowDOM] = useState([]);
   const isInitialMount = useRef(true);
-  const uniqueId = Math.floor(Math.random() * 100000)+1;
+  const [uniqueId, setUniqueId] = useState(0);
 
   useEffect(() => {
     if (!disabled) {
       if (isInitialMount.current) {
+        setUniqueId(Math.floor(Math.random() * 100000)+1);
         if (!!highlightStyle) {
           addStyleString(
             `

--- a/src/ChangeHighlight.tsx
+++ b/src/ChangeHighlight.tsx
@@ -31,6 +31,7 @@ const ChangeHighlight: React.FC<Props> = ({
 }) => {
   const [shadowDOM, setShadowDOM] = useState([]);
   const isInitialMount = useRef(true);
+  const uniqueId = Math.floor(Math.random() * 100000)+1;
 
   useEffect(() => {
     if (!disabled) {
@@ -66,6 +67,7 @@ const ChangeHighlight: React.FC<Props> = ({
           highlightStyle={highlightStyle}
           clearHandler={listOfClearHighlightFunctions[index]}
           updateClearHandler={updateClearHandler}
+          uniqueId={uniqueId}
         />
       ))}
       {children}

--- a/src/ShadowChild.tsx
+++ b/src/ShadowChild.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import setHighlight from "./Util/setHighlight";
+import defaults from "./consts";
 
 type Props = {
   child: any;
@@ -29,7 +30,7 @@ const ShadowChild: React.FC<Props> = ({
     : child.props.children;
 
   const elementDOM = child.ref.current;
-  elementDOM.setAttribute('react-change-hightlight-uniqueId',uniqueId);
+  elementDOM.setAttribute(defaults.HIGHLIGHT_UNIQUEID,uniqueId);
 
   useEffect(() => {
     if (initialMount.current) {

--- a/src/ShadowChild.tsx
+++ b/src/ShadowChild.tsx
@@ -9,6 +9,7 @@ type Props = {
   highlightStyle: string;
   clearHandler: number;
   updateClearHandler: Function;
+  uniqueId: number;
 };
 
 const ShadowChild: React.FC<Props> = ({
@@ -18,13 +19,17 @@ const ShadowChild: React.FC<Props> = ({
   hideAfter,
   highlightStyle,
   clearHandler,
-  updateClearHandler
+  updateClearHandler,
+  uniqueId
 }) => {
   const initialMount = useRef(true);
   const [clearHighlightRef, setClearHighlightRef] = useState(clearHandler);
   const changedChildren = Array.isArray(child.props.children)
     ? child.props.children.find(c => c.toString().trim().length)
     : child.props.children;
+
+  const elementDOM = child.ref.current;
+  elementDOM.setAttribute('react-change-hightlight-uniqueId',uniqueId);
 
   useEffect(() => {
     if (initialMount.current) {
@@ -41,7 +46,8 @@ const ShadowChild: React.FC<Props> = ({
       highlightStyle,
       clearHighlightRef,
       setClearHighlightRef,
-      updateClearHandler
+      updateClearHandler,
+      uniqueId
     );
   }, [changedChildren]);
 

--- a/src/ShadowChild.tsx
+++ b/src/ShadowChild.tsx
@@ -30,7 +30,7 @@ const ShadowChild: React.FC<Props> = ({
     : child.props.children;
 
   const elementDOM = child.ref.current;
-  elementDOM.setAttribute(defaults.HIGHLIGHT_UNIQUEID,uniqueId);
+  elementDOM.setAttribute(defaults.HIGHLIGHT_UNIQUE_ID,uniqueId);
 
   useEffect(() => {
     if (initialMount.current) {

--- a/src/Util/setHighlight.ts
+++ b/src/Util/setHighlight.ts
@@ -7,10 +7,13 @@ const setHighlight = (
   highlightStyle: string,
   clearHighlightRef: number,
   setClearHighlightFn: Function,
-  updateClearHandler: Function
+  updateClearHandler: Function,
+  uniqueId: number
 ) => {
-  if (!isInitial && child.ref.current) {
-    const element = child.ref.current;
+
+  const element = child.ref.current;
+
+  if (!isInitial && element && element.getAttribute('react-change-hightlight-uniqueId') == uniqueId) {
 
     if (clearHighlightRef) {
       clearTimeout(clearHighlightRef);

--- a/src/Util/setHighlight.ts
+++ b/src/Util/setHighlight.ts
@@ -1,3 +1,5 @@
+import defaults from "../consts"
+
 const setHighlight = (
   child: any,
   id: number,
@@ -12,8 +14,8 @@ const setHighlight = (
 ) => {
 
   const element = child.ref.current;
-
-  if (!isInitial && element && element.getAttribute('react-change-hightlight-uniqueId') == uniqueId) {
+  
+  if (!isInitial && element && parseInt(element.getAttribute(defaults.HIGHLIGHT_UNIQUEID)) === uniqueId) {
 
     if (clearHighlightRef) {
       clearTimeout(clearHighlightRef);

--- a/src/Util/setHighlight.ts
+++ b/src/Util/setHighlight.ts
@@ -14,8 +14,8 @@ const setHighlight = (
 ) => {
 
   const element = child.ref.current;
-  
-  if (!isInitial && element && parseInt(element.getAttribute(defaults.HIGHLIGHT_UNIQUEID)) === uniqueId) {
+
+  if (!isInitial && element && parseInt(element.getAttribute(defaults.HIGHLIGHT_UNIQUE_ID)) === uniqueId) {
 
     if (clearHighlightRef) {
       clearTimeout(clearHighlightRef);

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -2,5 +2,5 @@ export default {
   TIME_TO_HIGHLIGHT: 500,
   TIME_TO_STOP_HIGHLIGHT: 2000,
   HIGHLIGHT_CLASS: "rc-highlight",
-  HIGHLIGHT_UNIQUEID: "rc-highlight-id"
+  HIGHLIGHT_UNIQUE_ID: "rc-highlight-id"
 };

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,5 +1,6 @@
 export default {
   TIME_TO_HIGHLIGHT: 500,
   TIME_TO_STOP_HIGHLIGHT: 2000,
-  HIGHLIGHT_CLASS: "rc-highlight"
+  HIGHLIGHT_CLASS: "rc-highlight",
+  HIGHLIGHT_UNIQUEID: "rc-highlight-id"
 };


### PR DESCRIPTION
This PR is meant to fix : https://github.com/medhatdawoud/react-change-highlight/issues/8

The code I'm using :

![code](https://user-images.githubusercontent.com/18349358/68541922-3cf36b80-03ae-11ea-8ba0-2f3a67c60f27.PNG)

Before : 

![before](https://user-images.githubusercontent.com/18349358/68541925-4250b600-03ae-11ea-997a-e08655c933ce.gif)

After : 

![after](https://user-images.githubusercontent.com/18349358/68541927-47156a00-03ae-11ea-9318-70ad6df85727.gif)
